### PR TITLE
Update flask from 0.12 -> 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apk --upgrade add --no-cache git \
   
 WORKDIR /root/http-request-catcher
 
-RUN pip install --no-cache-dir -r requirements.txt -t .
+RUN pip install --no-cache-dir flask==1.1.2 -t .
 
 # Prod
 FROM base as prod


### PR DESCRIPTION
## What does this PR do?
This PR updates Flask to a recent version, addressing the following bug with GET `/__last_request__`.

http-request-catcher runs on flask 0.12, and the `is_xhr` method, shown below` was [deprecated](https://stackoverflow.com/a/60995530) and removed.
 ```
  File "/home/catcher/werkzeug/local.py", line 347, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'Request' object has no attribute 'is_xhr'
172.17.0.1 - - [03/Jan/2021 14:18:14] "GET /__last_request__ HTTP/1.1" 500 -

```
## Test Plan

- GET `/__last_request__` returns null
- GET `/` returns 200
- GET `/__last_request__` returns response

## Related PRs and Issues

N/A

### Have you read the [Contributing Guidelines on issues](https://github.com/appwrite/appwrite/blob/master/CONTRIBUTING.md)?

Yes.
