### PR TITLE
Handle sigint stopsignal to allow for immediate restart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ COPY --chown=catcher:catcher --from=build /root/http-request-catcher /home/catch
 
 EXPOSE 5000
 
+STOPSIGNAL SIGINT
+
 CMD ["python", "app.py"]

--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ This container supports all environment variables supplied by the original smart
 ### Build
 
 ```bash
-docker build --tag appwrite/requestcatcher:1.0.0 .
+docker build --tag appwrite/requestcatcher:1.1.0 .
 
-docker push appwrite/requestcatcher:1.0.0
+docker push appwrite/requestcatcher:1.1.0
 ```
 
 Multi-arch build (experimental using [buildx](https://github.com/docker/buildx)):
 
 ```
-docker buildx build --platform linux/amd64,linux/arm64/v8 --tag appwrite/requestcatcher:1.0.0 --push .
+docker buildx build --platform linux/amd64,linux/arm64/v8 --tag appwrite/requestcatcher:1.1.0 --push .
 ```
 
 ## Find Us


### PR DESCRIPTION
`requestcatcher` does not respond to `SIGTERM/SIGINT` sent from Docker when the container should be stopped or restarted. This causes ~10 second delay as Docker then comes around with a `SIGKILL` to force kill the container. 

This PR adds the `STOPSIGNAL` instruction to the Dockerfile so `docker-compose` doesn't need to wait for it to stop:
![dockerrequestcatcher](https://user-images.githubusercontent.com/9708641/136208250-18ccaba4-8ff0-43ea-bdd4-545a8394666a.png)
