### PR TITLE
Add configurable catcher responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ curl -X POST http://localhost:5000/__clear__
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `MAX_REQUEST_HISTORY` | 1000 | Maximum number of requests to store in history. Older requests are automatically removed when this limit is exceeded. |
+| `RESPONSE_BODY` | Empty | Body returned for captured requests. |
+| `RESPONSE_CONTENT_TYPE` | `text/html; charset=utf-8` | Content type returned for captured requests. |
+| `RESPONSE_STATUS_CODE` | 200 | Status code returned for captured requests. |
 
 This container also supports all environment variables supplied by the original smarterdm/http-request-catcher Docker image.
 
@@ -105,4 +108,3 @@ docker buildx build --platform linux/amd64,linux/arm64/v8 --tag appwrite/request
 ## Copyright and license
 
 The MIT License (MIT) [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)
-

--- a/app.py
+++ b/app.py
@@ -7,6 +7,9 @@ app = Flask('HTTP Request Catcher')
 
 # Maximum number of requests to store in history (configurable via environment variable)
 MAX_REQUEST_HISTORY = int(environ.get('MAX_REQUEST_HISTORY', 1000))
+RESPONSE_BODY = environ.get('RESPONSE_BODY', '')
+RESPONSE_CONTENT_TYPE = environ.get('RESPONSE_CONTENT_TYPE', 'text/html; charset=utf-8')
+RESPONSE_STATUS_CODE = int(environ.get('RESPONSE_STATUS_CODE', 200))
 
 last_request = None
 all_requests = deque(maxlen=MAX_REQUEST_HISTORY)
@@ -85,7 +88,7 @@ def catch(path):
     }
     all_requests.append(last_request)
 
-    return '', 200
+    return RESPONSE_BODY, RESPONSE_STATUS_CODE, {'Content-Type': RESPONSE_CONTENT_TYPE}
 
 
 if __name__ == '__main__':

--- a/test_app.py
+++ b/test_app.py
@@ -1,5 +1,4 @@
 """Tests for the HTTP Request Catcher API."""
-import json
 import pytest
 from app import app, all_requests, MAX_REQUEST_HISTORY
 
@@ -50,6 +49,19 @@ class TestCatchEndpoint:
             headers={'X-Custom-Header': 'custom-value'}
         )
         assert response.status_code == 200
+
+    def test_catch_returns_configured_response(self, client, monkeypatch):
+        """Test returning a configured response while still capturing the request."""
+        monkeypatch.setattr('app.RESPONSE_BODY', '{"success":true}')
+        monkeypatch.setattr('app.RESPONSE_CONTENT_TYPE', 'application/json')
+        monkeypatch.setattr('app.RESPONSE_STATUS_CODE', 202)
+
+        response = client.post('/purge', data='request-body')
+
+        assert response.status_code == 202
+        assert response.content_type == 'application/json'
+        assert response.json == {'success': True}
+        assert all_requests[-1]['data'] == 'request-body'
 
 
 class TestLastRequestEndpoint:


### PR DESCRIPTION
## What changed

- add environment variables for configuring the response body, content type, and status code returned by captured requests
- preserve the existing empty `200` defaults
- document the new configuration and cover it with a request-capture test

## Why

External API integration tests need the catcher to record requests while returning a realistic provider response. Without response configuration, consumers must either accept an invalid empty response or replace the catcher's application inside the container.

## Validation

- `pytest test_app.py -q` (29 passed)
- `git diff --check`
